### PR TITLE
Core lock suffix

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -1379,6 +1379,9 @@ func (c *ServerCommand) Run(args []string) int {
 		}
 	}
 
+	info["core lock"] = vault.CoreLockPath
+	infoKeys = append(infoKeys, "core lock")
+
 	status, lns, clusterAddrs, errMsg := c.InitListeners(config, disableClustering, &infoKeys, &info)
 
 	if status != 0 {

--- a/command/server.go
+++ b/command/server.go
@@ -2924,6 +2924,7 @@ func createCoreConfig(c *ServerCommand, config *server.Config, backend physical.
 		DisableSSCTokens:               config.DisableSSCTokens,
 		Experiments:                    config.Experiments,
 		AdministrativeNamespacePath:    config.AdministrativeNamespacePath,
+		CoreLockSuffix:                 config.CoreLockSuffix,
 	}
 
 	if c.flagDev {

--- a/internalshared/configutil/config.go
+++ b/internalshared/configutil/config.go
@@ -54,7 +54,9 @@ type SharedConfig struct {
 
 	ClusterName string `hcl:"cluster_name"`
 
-	AdministrativeNamespacePath string `hcl:"administrative_namespace_path"`
+	AdministrativeNamespacePath string      `hcl:"administrative_namespace_path"`
+	CoreLockSuffix              string      `hcl:"-"`
+	CoreLockSuffixRaw           interface{} `hcl:"core_lock_suffix"`
 }
 
 func ParseConfig(d string) (*SharedConfig, error) {
@@ -85,6 +87,14 @@ func ParseConfig(d string) (*SharedConfig, error) {
 		}
 		result.FoundKeys = append(result.FoundKeys, "DisableMlock")
 		result.DisableMlockRaw = nil
+	}
+
+	if result.CoreLockSuffixRaw != nil {
+		if result.CoreLockSuffix, err = parseutil.ParseString(result.CoreLockSuffixRaw); err != nil {
+			return nil, err
+		}
+		result.FoundKeys = append(result.FoundKeys, "CoreLockSuffix")
+		result.CoreLockSuffixRaw = nil
 	}
 
 	list, ok := obj.Node.(*ast.ObjectList)
@@ -184,6 +194,7 @@ func (c *SharedConfig) Sanitized() map[string]interface{} {
 		"pid_file":                      c.PidFile,
 		"cluster_name":                  c.ClusterName,
 		"administrative_namespace_path": c.AdministrativeNamespacePath,
+		"core_lock_suffix":              c.CoreLockSuffix,
 	}
 
 	// Optional log related settings

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -18,7 +18,7 @@
       },
       "engines": {
         "node": ">=18.17.0 <= 20.x",
-        "npm": ">=9.8.0"
+        "npm": ">=9.6.7"
       }
     },
     "node_modules/@babel/code-frame": {


### PR DESCRIPTION
### Description
Allows the User to specify a core_lock_suffix setting so that multiple vaults can run on the same mysql instance
